### PR TITLE
fix: Start My Cycle navigates reliably after save (closes #2)

### DIFF
--- a/app/auth/onboarding/page.tsx
+++ b/app/auth/onboarding/page.tsx
@@ -103,7 +103,8 @@ export default function OnboardingPage() {
       if (!res.ok) throw new Error('Failed to save cycle')
 
       logSessionEvent('onboarding', data.startingWeek)
-      router.push('/')
+      setSavingCycle(false)
+      window.location.replace('/')
     } catch (err) {
       console.error('Failed to save cycle:', err)
       setSavingCycle(false)


### PR DESCRIPTION
Fixes #2

Adds setSavingCycle(false) before navigation and uses window.location.replace('/') instead of router.push('/') to force a full page load, ensuring the middleware reads the anonymous session cookie correctly.