### PR TITLE
fix: trust explicit start_date for Week 1 onboarding (closes #3)

### DIFF
--- a/app/api/cycle/route.ts
+++ b/app/api/cycle/route.ts
@@ -105,13 +105,18 @@ export async function PUT(request: Request) {
   }
 
   if (current_week !== undefined && current_week >= 1 && current_week <= 12) {
-    // Season jump: recalculate start_date
-    const jumpDate = seasonJumpStartDate(current_week, timezone)
-    if (!jumpDate) {
-      return Response.json({ error: 'Failed to calculate cycle date' }, { status: 400 })
-    }
     updatePayload.current_week = current_week
-    updatePayload.start_date = jumpDate
+    if (current_week === 1 && start_date) {
+      // Week 1 with explicit start_date: trust it (fresh start from onboarding)
+      updatePayload.start_date = start_date
+    } else {
+      // Season jump: compute start_date aligned to the target week
+      const jumpDate = seasonJumpStartDate(current_week, timezone)
+      if (!jumpDate) {
+        return Response.json({ error: 'Failed to calculate cycle date' }, { status: 400 })
+      }
+      updatePayload.start_date = jumpDate
+    }
   } else if (start_date) {
     updatePayload.start_date = start_date
   }


### PR DESCRIPTION
Fixes #3

When onboarding submits current_week=1 with an explicit start_date, the API was ignoring start_date and calling seasonJumpStartDate(1) which backdates to the most recent Monday. If today is Wednesday that produces Day 3 instead of Day 1.

Now Week 1 + explicit start_date uses the provided date directly.