### PR TITLE
fix: persist dark mode across page navigation (closes #22)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,6 +36,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: `(function(){try{var t=localStorage.getItem('lw-theme');if(t==='dark'||t==='light'){document.documentElement.setAttribute('data-theme',t);}else{var mq=window.matchMedia('(prefers-color-scheme: dark)');document.documentElement.setAttribute('data-theme',mq.matches?'dark':'light');}}catch(e){}})();` }} />
+      </head>
       <body className="min-h-screen flex flex-col">
         <TopNav />
         <main className="flex-1 pb-16 md:pb-0">

--- a/components/settings/AppearanceSection.tsx
+++ b/components/settings/AppearanceSection.tsx
@@ -22,10 +22,13 @@ export function AppearanceSection({ currentTheme, userId, onThemeChange }: Appea
   const supabase = createClient()
 
   const handleThemeChange = async (theme: Theme) => {
-    // Apply immediately
-    document.documentElement.setAttribute('data-theme', theme === 'system' ? '' : theme)
+    // Apply immediately and persist to localStorage for cross-page init
     if (theme === 'system') {
       document.documentElement.removeAttribute('data-theme')
+      localStorage.removeItem('lw-theme')
+    } else {
+      document.documentElement.setAttribute('data-theme', theme)
+      localStorage.setItem('lw-theme', theme)
     }
     onThemeChange(theme)
 


### PR DESCRIPTION
Fixes #22

Adds an inline script in the root layout `<head>` that runs synchronously before hydration and sets `data-theme` from localStorage, preventing the theme resetting on navigation.

AppearanceSection now writes the selected theme to localStorage (`lw-theme`) in addition to Supabase, so the layout script can read it on every page load.