### PR TITLE
fix: error states use amber banner styling (closes #23)

### DIFF
--- a/app/foods/page.tsx
+++ b/app/foods/page.tsx
@@ -97,9 +97,11 @@ export default function FoodsPage() {
 
   if (error && foods.length === 0) {
     return (
-      <div className="max-w-2xl mx-auto px-4 py-8 text-center space-y-4">
-        <p className="text-[var(--text-secondary)]">{error}</p>
-        <Button variant="secondary" onClick={loadData}>Retry</Button>
+      <div className="max-w-2xl mx-auto px-4 py-6">
+        <div className="rounded-xl bg-[var(--status-moderation-bg)] border border-[var(--status-moderation-border)] px-4 py-4 flex flex-col items-center gap-3 text-center">
+          <p className="text-sm text-[var(--status-moderation-text)]">{error}</p>
+          <Button variant="secondary" size="sm" onClick={loadData}>Retry</Button>
+        </div>
       </div>
     )
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -132,9 +132,11 @@ export default function HomePage() {
 
   if (error) {
     return (
-      <div className="max-w-2xl mx-auto px-4 py-8 text-center space-y-4">
-        <p className="text-[var(--text-secondary)]">{error}</p>
-        <Button variant="secondary" onClick={loadCycleAndFoods}>Retry</Button>
+      <div className="max-w-2xl mx-auto px-4 py-6">
+        <div className="rounded-xl bg-[var(--status-moderation-bg)] border border-[var(--status-moderation-border)] px-4 py-4 flex flex-col items-center gap-3 text-center">
+          <p className="text-sm text-[var(--status-moderation-text)]">{error}</p>
+          <Button variant="secondary" size="sm" onClick={loadCycleAndFoods}>Retry</Button>
+        </div>
       </div>
     )
   }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -103,9 +103,11 @@ export default function SettingsPage() {
 
   if (error) {
     return (
-      <div className="max-w-2xl mx-auto px-4 py-8 text-center space-y-4">
-        <p className="text-[var(--text-secondary)]">{error}</p>
-        <Button variant="secondary" onClick={loadData}>Retry</Button>
+      <div className="max-w-2xl mx-auto px-4 py-6">
+        <div className="rounded-xl bg-[var(--status-moderation-bg)] border border-[var(--status-moderation-border)] px-4 py-4 flex flex-col items-center gap-3 text-center">
+          <p className="text-sm text-[var(--status-moderation-text)]">{error}</p>
+          <Button variant="secondary" size="sm" onClick={loadData}>Retry</Button>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
Fixes #23

Replaces the plain centered text error states on /, /foods, and /settings with amber-styled retry banners using the status-moderation CSS variables, matching the PRD specification.